### PR TITLE
Fix typo with the `--scheme` option for the http command

### DIFF
--- a/examples/agent-cli/http-schemes.mdx
+++ b/examples/agent-cli/http-schemes.mdx
@@ -1,3 +1,3 @@
 ```bash
-ngrok http 80 --schemes http,https
+ngrok http 80 --scheme http,https
 ```


### PR DESCRIPTION
The option for selecting the scheme for `ngrok http` is `--scheme` not `--schemes`

![Screenshot 2023-12-03 at 1 18 56 AM](https://github.com/kevinlutzer/ngrok-docs/assets/26232349/3d87c602-d3ce-4cfc-b9a7-1f85cbfdd1cf)
